### PR TITLE
Add "Install with Herd" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 ![GitHub last commit](https://img.shields.io/github/last-commit/mortenebak/laravel-starter-project)
 ![GitHub Sponsors](https://img.shields.io/github/sponsors/mortenebak)
+<a href="https://herd.laravel.com/new?starter-kit=mortenebak/tallstarter"><img src="https://img.shields.io/badge/Install%20with%20Herd-f55247?logo=laravel&logoColor=white"></a>
+
 
 Complete **User Management**, **Role Management** and **Permissions Management** with a Dashboard for Admins.
 ![alt text](docs/backend.png "Backend View")


### PR DESCRIPTION
This PR adds an "Install with Herd" button.
When you have Herd installed, users can install this starter kit with a single click, which will show them the site creation wizard with your starter kit already pre-defined.

![CleanShot 2025-03-11 at 15 53 17@2x](https://github.com/user-attachments/assets/bf7e01ff-f615-4a32-9d08-f115a1451c9c)
