### PR TITLE
Update route redirection

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@ Route::middleware(['auth'])->group(function (): void {
     Route::delete('/impersonate/stop', [\App\Http\Controllers\ImpersonationController::class, 'destroy'])->name('impersonate.destroy');
 
     // Settings
-    Route::redirect('settings', 'settings/profile');
+    Route::redirect('settings', '/settings/profile');
     Route::get('settings/profile', \App\Livewire\Settings\Profile::class)->name('settings.profile');
     Route::get('settings/password', \App\Livewire\Settings\Password::class)->name('settings.password');
     Route::get('settings/appearance', \App\Livewire\Settings\Appearance::class)->name('settings.appearance');


### PR DESCRIPTION
Current route redirection `Route::redirect('settings', 'settings/profile');` in case if URL is with a trailing slash at the end adds another `'settings/profile'` segment to the URL instead of redirecting (as this: `http://tall-starter.test/settings/settings/profile`). Adding a slash to the redirection solves the problem: `Route::redirect('settings', '/settings/profile');`.